### PR TITLE
Minor improvements to MacOS X instructions

### DIFF
--- a/source/installation/macosx.rst
+++ b/source/installation/macosx.rst
@@ -4,16 +4,26 @@ Mac OSX
 =======
 
 First download the appropriate Mac OSX EPD installer from the `EPD downloads
-<http://cxc.cfa.harvard.edu/contrib/python4astronomers>`_ page.  The user name
-and password were emailed to the pythonusers mailing list
+<http://cxc.cfa.harvard.edu/contrib/python4astronomers>`_ page. The user name
+and password were emailed to the pythonusers mailing list.
 
-The follow the instructions for `Getting Started with EPD
-<http://www.enthought.com/products/epdgetstart.php?platform=mac>`_ for
-Mac OSX.  Choose all the defaults for installing (in particular use the default installation location).
+.. note:: If you are using MacOS X 10.5 or 10.6, we recommend that you install
+          the 64-bit version (``epd-7.0-2-macosx-x86_64.dmg``). If you are
+          using a PPC mac with MacOS X 10.4, you will need to download a
+          special PPC 32-bit version (``epd_py25-4.2.30201-macosx-u.dmg``)
 
-Once installed then follow the
-Getting Started page and look at Pylab, Plain Python and see how to write
-Python code.
+After downloading the disk image, open it, then double-click on EPD.mpkg and
+follow the prompts to install. Choose all the defaults for installing (in
+particular use the default installation location).
+
+Once installed then follow the `Running Pylab
+<http://www.enthought.com/products/epdgetstart.php?platform=mac#pylab>`_,
+`Plain Python
+<http://www.enthought.com/products/epdgetstart.php?platform=mac#plain>`_ and
+the `Writing Python Code
+<http://www.enthought.com/products/epdgetstart.php?platform=mac#writing>`_
+sections on the `Getting Started with EPD
+<http://www.enthought.com/products/epdgetstart.php?platform=mac>`_ page.
 
 Next open a terminal window and do the following::
 


### PR DESCRIPTION
The installation instructions are so simple that I think for that step it's not worth referring people to the Getting started page - in fact, I find the installation instructions on 'getting started' a bit confusing when in fact it can be said much more simply.
