### PR TITLE
Update astropy.rst for urllib change

### DIFF
--- a/source/astropy/astropy.rst
+++ b/source/astropy/astropy.rst
@@ -32,7 +32,7 @@ Please download this
 the content, either by clicking on the link or by executing this
 python code::
 
-    from astropy.extern.six.moves.urllib import request
+    from urllib import request
     import tarfile
     url = 'http://python4astronomers.github.io/_downloads/astropy_examples.tar'
     tarfile.open(fileobj=request.urlopen(url), mode='r|').extractall()


### PR DESCRIPTION
The module astropy.extern.six.moves.urllib no longer exists. Change the behavior in this tutorial to use the python urllib.